### PR TITLE
changed order of dot product

### DIFF
--- a/math_linear_algebra.ipynb
+++ b/math_linear_algebra.ipynb
@@ -3659,7 +3659,7 @@
     "editable": true
    },
    "source": [
-    "Now let's look at the dot product $P \\cdot U$:"
+    "Now let's look at the dot product $U \\cdot P$:"
    ]
   },
   {
@@ -5539,7 +5539,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.5.2"
   },
   "toc": {
    "toc_cell": false,


### PR DESCRIPTION
I could be wrong, but I think the order specified in the markdown text does not match up with the code for this part of the linear algebra tutorial.