### PR TITLE
Update 15_autoencoders.ipynb

### DIFF
--- a/15_autoencoders.ipynb
+++ b/15_autoencoders.ipynb
@@ -131,6 +131,8 @@
    },
    "outputs": [],
    "source": [
+    "import numpy.random as rnd\n",
+    "\n",
     "rnd.seed(4)\n",
     "m = 200\n",
     "w1, w2 = 0.1, 0.3\n",


### PR DESCRIPTION
PCA with a linear Autoencoder Section:
The calls to numpy.random require an import to work. 
Added:
import numpy.random as rnd