### PR TITLE
Docker environment enhancements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,66 @@
 FROM continuumio/anaconda3
 
-WORKDIR /usr/src/project
-COPY . /usr/src/project
-
 RUN apt-get update && apt-get upgrade -y \
-	
 	&& apt-get install -y \
-	 	libpq-dev \
-	 	build-essential \
-	 	git \
+		libpq-dev \
+		build-essential \
+		git \
+		sudo \
+	&& rm -rf /var/lib/apt/lists/*
 
-	&& rm -rf /var/lib/apt/lists/* \
+RUN conda install -y -c conda-forge \
+		tensorflow=1.0.0 \
+		jupyter_contrib_nbextensions
 
-	&& conda install -y -c conda-forge tensorflow=1.0.0 \
-	&& conda install -y -c conda-forge jupyter_contrib_nbextensions \
+ARG username
 
-	&& jupyter contrib nbextension install --user \
-	&& jupyter nbextension enable toc2/main 
+RUN adduser ${username} --gecos '' --disabled-password && \
+	echo "${username} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${username} && \
+	chmod 0440 /etc/sudoers.d/${username}
+
+ENV HOME /home/${username}
+
+WORKDIR ${HOME}/handson-ml
+RUN chown ${username}:${username} ${HOME}/handson-ml
+
+USER ${username}
+
+RUN jupyter contrib nbextension install --user
+RUN jupyter nbextension enable toc2/main
+
+
+# INFO: Have RUN command below uncommented to for easy and constant URL (just localhost:8888)
+#       (by setting empty password instead of using a token)
+#       To avoid making a security hole the best would be to regenerate a hash for
+#       your own non-empty password and to replace the hash below.
+#       You can compute a password hash in the notebook, just run the code:
+#          from notebook.auth import passwd
+#          passwd()
+RUN mkdir -p ${HOME}/.jupyter && \
+	echo 'c.NotebookApp.password = u"sha1:c6bbcba2d04b:f969e403db876dcfbe26f47affe41909bd53392e"' \
+	>> ${HOME}/.jupyter/jupyter_notebook_config.py
+
+
+# INFO: Below - work in progress, nbdime not totally integrated, still:
+# 1. enables diffing notebooks via nbdiff after connecting to container by "make exec" (docker exec)
+#  Use:
+#      nbd NOTEBOOK_NAME.ipynb
+#    to get nbdiff between checkpointed version and current version of the given notebook
+# 2. allows decision tree visualization in notebook
+#  Use:
+#      from sklearn import tree
+#      from graphviz import Source
+#      Source(tree.export_graphviz(tree_clf, out_file=None, feature_names=iris.feature_names[2:]))
+
+USER root
+WORKDIR /
+
+RUN conda install -y -c conda-forge nbdime
+RUN conda install -y -c conda-forge python-graphviz
+
+USER ${username}
+WORKDIR ${HOME}/handson-ml
+
+COPY docker/bashrc /tmp/bashrc
+RUN cat /tmp/bashrc >> ${HOME}/.bashrc
+RUN sudo rm -rf /tmp/bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,25 +41,17 @@ RUN mkdir -p ${HOME}/.jupyter && \
 	>> ${HOME}/.jupyter/jupyter_notebook_config.py
 
 
-# INFO: Below - work in progress, nbdime not totally integrated, still:
-# 1. enables diffing notebooks via nbdiff after connecting to container by "make exec" (docker exec)
+# INFO: Below - work in progress, nbdime not totally integrated, still it enables diffing
+#       notebooks via nbdiff after connecting to container by "make exec" (docker exec)
 #  Use:
 #      nbd NOTEBOOK_NAME.ipynb
 #    to get nbdiff between checkpointed version and current version of the given notebook
-# 2. allows decision tree visualization in notebook
-#  Use:
-#      from sklearn import tree
-#      from graphviz import Source
-#      Source(tree.export_graphviz(tree_clf, out_file=None, feature_names=iris.feature_names[2:]))
-
 USER root
 WORKDIR /
-
 RUN conda install -y -c conda-forge nbdime
-RUN conda install -y -c conda-forge python-graphviz
-
 USER ${username}
 WORKDIR ${HOME}/handson-ml
+
 
 COPY docker/bashrc /tmp/bashrc
 RUN cat /tmp/bashrc >> ${HOME}/.bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,9 @@ RUN conda install -y -c conda-forge \
 ARG username
 ARG userid
 
-RUN adduser ${username} --uid ${userid} --gecos '' --disabled-password && \
-	echo "${username} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${username} && \
-	chmod 0440 /etc/sudoers.d/${username}
+RUN adduser ${username} --uid ${userid} --gecos '' --disabled-password \
+	&& echo "${username} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${username} \
+	&& chmod 0440 /etc/sudoers.d/${username}
 
 ENV HOME /home/${username}
 
@@ -30,28 +30,40 @@ RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable toc2/main
 
 
-# INFO: Have RUN command below uncommented to for easy and constant URL (just localhost:8888)
-#       (by setting empty password instead of using a token)
-#       To avoid making a security hole the best would be to regenerate a hash for
-#       your own non-empty password and to replace the hash below.
-#       You can compute a password hash in the notebook, just run the code:
+# INFO: Uncomment the RUN command below for easy and constant notebook URL (just localhost:8888)
+#       That will switch jupyter to using empty password instead of a token.
+#       To avoid making a security hole you SHOULD in fact not only uncomment but
+#       regenerate the hash for your own non-empty password and replace the hash below.
+#       You can compute a password hash in any notebook, just run the code:
 #          from notebook.auth import passwd
 #          passwd()
-RUN mkdir -p ${HOME}/.jupyter && \
-	echo 'c.NotebookApp.password = u"sha1:c6bbcba2d04b:f969e403db876dcfbe26f47affe41909bd53392e"' \
-	>> ${HOME}/.jupyter/jupyter_notebook_config.py
+#       and take the hash from the output
+#RUN mkdir -p ${HOME}/.jupyter && \
+#	echo 'c.NotebookApp.password = u"sha1:c6bbcba2d04b:f969e403db876dcfbe26f47affe41909bd53392e"' \
+#	>> ${HOME}/.jupyter/jupyter_notebook_config.py
+
+# INFO: Uncomment the RUN command below to disable git diff paging
+#RUN git config --global core.pager ''
 
 
 # INFO: Below - work in progress, nbdime not totally integrated, still it enables diffing
-#       notebooks via nbdiff after connecting to container by "make exec" (docker exec)
-#  Use:
+#       notebooks with nbdiff (and nbdiff support in git diff command) after connecting to
+#       the container by "make exec" (docker exec)
+#  Try:
 #      nbd NOTEBOOK_NAME.ipynb
 #    to get nbdiff between checkpointed version and current version of the given notebook
 USER root
 WORKDIR /
+
 RUN conda install -y -c conda-forge nbdime
+
 USER ${username}
 WORKDIR ${HOME}/handson-ml
+
+RUN git-nbdiffdriver config --enable --global
+
+# INFO: Uncomment the RUN command below to ignore metadata in nbdiff within git diff
+#RUN git config --global diff.jupyternotebook.command 'git-nbdiffdriver diff --ignore-metadata'
 
 
 COPY docker/bashrc /tmp/bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,9 @@ RUN conda install -y -c conda-forge \
 		jupyter_contrib_nbextensions
 
 ARG username
+ARG userid
 
-RUN adduser ${username} --gecos '' --disabled-password && \
+RUN adduser ${username} --uid ${userid} --gecos '' --disabled-password && \
 	echo "${username} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${username} && \
 	chmod 0440 /etc/sudoers.d/${username}
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,9 +4,11 @@ help:
 run:
 	docker-compose up
 exec:
-	docker-compose exec -ti hondson-ml /bin/bash
+	docker-compose exec handson-ml /bin/bash
 build: stop .FORCE
-	docker-compose build --force-rm 
+	docker-compose build
+rebuild: stop .FORCE
+	docker-compose build --force-rm
 stop:
 	docker stop handson-ml || true; docker rm handson-ml || true;
 .FORCE:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 
 # Hands-on Machine Learning in Docker :-)
 
-This is the Docker configuration which allows you to run and tweak the book's notebooks without installing any dependencies on your machine!
+This is the Docker configuration which allows you to run and tweak the book's notebooks without installing any dependencies on your machine!<br/>
 OK, any except `docker`. With `docker-compose`. Well, you may also want `make` (but it is only used as thin layer to call a few simple `docker-compose` commands).
 
 ## Prerequisites
@@ -22,7 +22,7 @@ After the process is finished you have a `handson-ml` image, that will be the ba
 
 ### Run the notebooks
 
-Run `make run` (or just `docker-compose up`) to start the jupyter server inside the container (also named `handson-ml`, same as image). Just point your browser to <http://localhost:8888> or the URL printed on the screen and you're ready to play with the book's code!
+Run `make run` (or just `docker-compose up`) to start the jupyter server inside the container (also named `handson-ml`, same as image). Just point your browser to <http://localhost:8888> (empty password) or the URL printed on the screen and you're ready to play with the book's code!
 
 The server runs in the directory containing the notebooks, and the changes you make from the browser will be persisted there.
 
@@ -32,6 +32,7 @@ You can close the server just by pressing `Ctrl-C` in terminal window.
 
 Run `make exec` (or `docker-compose exec handson-ml bash`) while the server is running to run an additional `bash` shell inside the `handson-ml` container. Now you're inside the environment prepared within the image.
 
-One of the usefull things that can be done there may be comparing versions of the notebooks using the `nbdiff` command if you haven't got `nbdime` installed locally (it is **way** better than plain `diff` for notebooks). See [Tools for diffing and merging of Jupyter notebooks]<https://github.com/jupyter/nbdime> for more details.
+One of the usefull things that can be done there may be comparing versions of the notebooks using the `nbdiff` command if you haven't got `nbdime` installed locally (it is **way** better than plain `diff` for notebooks). See [Tools for diffing and merging of Jupyter notebooks](https://github.com/jupyter/nbdime) for more details.
 
-You may also try `nbd NOTEBOOK_NAME.ipynb` command (custom, defined in the Dockerfile) to compare one of your notebooks with its `checkpointed` version. To be precise, the output will tell you "what modifications should be re-played on the *manually saved* version of the notebook (located in `.ipynb_checkpoints` subdirectory) to update it to the *current* i.e. *auto-saved* version (given as command's argument - located in working directory)".
+You may also try `nbd NOTEBOOK_NAME.ipynb` command (custom, see bashrc file) to compare one of your notebooks with its `checkpointed` version.<br/>
+To be precise, the output will tell you *what modifications should be re-played on the **manually saved** version of the notebook (located in `.ipynb_checkpoints` subdirectory) to update it to the **current** i.e. **auto-saved** version (given as command's argument - located in working directory)*.

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ After the process is finished you have a `handson-ml` image, that will be the ba
 
 ### Run the notebooks
 
-Run `make run` (or just `docker-compose up`) to start the jupyter server inside the container (also named `handson-ml`, same as image). Just point your browser to <http://localhost:8888> (empty password) or the URL printed on the screen and you're ready to play with the book's code!
+Run `make run` (or just `docker-compose up`) to start the jupyter server inside the container (also named `handson-ml`, same as image). Just point your browser to the URL printed on the screen (or just <http://localhost:8888> if you enabled password authentication) and you're ready to play with the book's code!
 
 The server runs in the directory containing the notebooks, and the changes you make from the browser will be persisted there.
 
@@ -33,6 +33,8 @@ You can close the server just by pressing `Ctrl-C` in terminal window.
 Run `make exec` (or `docker-compose exec handson-ml bash`) while the server is running to run an additional `bash` shell inside the `handson-ml` container. Now you're inside the environment prepared within the image.
 
 One of the usefull things that can be done there may be comparing versions of the notebooks using the `nbdiff` command if you haven't got `nbdime` installed locally (it is **way** better than plain `diff` for notebooks). See [Tools for diffing and merging of Jupyter notebooks](https://github.com/jupyter/nbdime) for more details.
+
+You can see changes you made relative to the version in git using `git diff` which is integrated with `nbdiff`.
 
 You may also try `nbd NOTEBOOK_NAME.ipynb` command (custom, see bashrc file) to compare one of your notebooks with its `checkpointed` version.<br/>
 To be precise, the output will tell you *what modifications should be re-played on the **manually saved** version of the notebook (located in `.ipynb_checkpoints` subdirectory) to update it to the **current** i.e. **auto-saved** version (given as command's argument - located in working directory)*.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,37 @@
+
+# Hands-on Machine Learning in Docker :-)
+
+This is the Docker configuration which allows you to run and tweak the book's notebooks without installing any dependencies on your machine!
+OK, any except `docker`. With `docker-compose`. Well, you may also want `make` (but it is only used as thin layer to call a few simple `docker-compose` commands).
+
+## Prerequisites
+
+As stated, the two things you need is `docker` and `docker-compose`.
+
+Follow the instructions on [Install Docker](https://docs.docker.com/engine/installation/) and [Install Docker Compose](https://docs.docker.com/compose/install/) for your environment if you haven't got `docker` already.
+
+Some general knowledge about `docker` infrastructure might be useful (that's an interesting topic on its own) but is not strictly *required* to just run the notebooks.
+
+## Usage
+
+### Prepare the image (once)
+
+Switch to `docker` directory here and run `make build` (or `docker-compose build`) to build your docker image. That may take some time but is only required once. Or perhaps a few times after you tweak something in a `Dockerfile`.
+
+After the process is finished you have a `handson-ml` image, that will be the base for your experiments. You can confirm that looking on results of `docker images` command.
+
+### Run the notebooks
+
+Run `make run` (or just `docker-compose up`) to start the jupyter server inside the container (also named `handson-ml`, same as image). Just point your browser to <http://localhost:8888> or the URL printed on the screen and you're ready to play with the book's code!
+
+The server runs in the directory containing the notebooks, and the changes you make from the browser will be persisted there.
+
+You can close the server just by pressing `Ctrl-C` in terminal window.
+
+### Run additional commands in container
+
+Run `make exec` (or `docker-compose exec handson-ml bash`) while the server is running to run an additional `bash` shell inside the `handson-ml` container. Now you're inside the environment prepared within the image.
+
+One of the usefull things that can be done there may be comparing versions of the notebooks using the `nbdiff` command if you haven't got `nbdime` installed locally (it is **way** better than plain `diff` for notebooks). See [Tools for diffing and merging of Jupyter notebooks]<https://github.com/jupyter/nbdime> for more details.
+
+You may also try `nbd NOTEBOOK_NAME.ipynb` command (custom, defined in the Dockerfile) to compare one of your notebooks with its `checkpointed` version. To be precise, the output will tell you "what modifications should be re-played on the *manually saved* version of the notebook (located in `.ipynb_checkpoints` subdirectory) to update it to the *current* i.e. *auto-saved* version (given as command's argument - located in working directory)".

--- a/docker/bashrc
+++ b/docker/bashrc
@@ -1,0 +1,12 @@
+alias ll="ls -l"
+
+nbd() {
+	DIRNAME=$(dirname "$1")
+	BASENAME=$(basename "$1" .ipynb)
+
+	WORKING_COPY=$DIRNAME/$BASENAME.ipynb
+	CHECKPOINT_COPY=$DIRNAME/.ipynb_checkpoints/$BASENAME-checkpoint.ipynb
+
+	# echo "How change $CHECKPOINT_COPY into $WORKING_COPY"
+	nbdiff "$CHECKPOINT_COPY" "$WORKING_COPY"
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3"
 services:
   handson-ml:
-    build: 
+    build:
       context: ../
       dockerfile: ./docker/Dockerfile
+      args:
+        - username=devel
     container_name: handson-ml
     image: handson-ml
     logging:
@@ -13,5 +15,5 @@ services:
     ports:
       - "8888:8888"
     volumes:
-      - ../:/usr/src/project
-    command: /opt/conda/bin/jupyter notebook --ip='*' --port=8888 --no-browser --allow-root
+      - ../:/home/devel/handson-ml
+    command: /opt/conda/bin/jupyter notebook --ip='*' --port=8888 --no-browser

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: ./docker/Dockerfile
       args:
         - username=devel
+        - userid=1000
     container_name: handson-ml
     image: handson-ml
     logging:


### PR DESCRIPTION
Hi,
that's a great idea to have notebooks easily runnable in a docker (thanks StevenBunkley)!

I am reading your (Aurélien) book for a week now, and I like it a lot! It's quite interestingly put up and contains some pieces I've been missing in online courses I've completed... It's also super useful to have everything in the notebooks, even visualizations that are in many books just included as pictures.

So as for now I've taken the Docker idea a step further and...

- rearranged a Dockerfile to allow for incremental build which is much more convenient for experimentation and tweaking (included :-D)
- switched running from root to "default new user" which can be better for "a standard linux user" because files in jupyter workspace will be written with permissions for that user and not for root (the name and UID for the user can be set in docker-compose.yml what should be easy to change for the people who would not like the default)
- added the configuration (easy to opt-out) to have a constant browser bookmark/shortcut by weakening jupyter's security a bit and enabling access with blank password instead of token which is more convenient to use in "controlled environment"
- added "nbdime" for "sensible notebook comparison" (still there seem to be some version collision with the jupyter which disables its integration inside notebooks)
- added a custom function in .bashrc to "nbdiff" a notebook with its "checkpointed" version
- added a simple README.md, hoping it could be helpful for some new users, you can change it or merge into your root one
- capitalized the filename of Makefile what is required on linux and corrected a typo inside

I wanted to add also python-graphiz to enable DT visualization in notebooks but it stopped working after I rebuilt the image after the weekend so I rolled it back. It may be that the approach of letting "apt-get" and "conda" choose package versions it a bit too fragile...

Regards