### PR TITLE
capsnet: fix margin loss formula

### DIFF
--- a/extra_capsnets.ipynb
+++ b/extra_capsnets.ipynb
@@ -1348,7 +1348,7 @@
    "source": [
     "The paper uses a special margin loss to make it possible to detect two or more different digits in each image:\n",
     "\n",
-    "$ L_k = T_k \\max(0, m^{+} - \\|\\mathbf{v}_k\\|)^2 - \\lambda (1 - T_k) \\max(0, \\|\\mathbf{v}_k\\| - m^{-})^2$\n",
+    "$ L_k = T_k \\max(0, m^{+} - \\|\\mathbf{v}_k\\|)^2 + \\lambda (1 - T_k) \\max(0, \\|\\mathbf{v}_k\\| - m^{-})^2$\n",
     "\n",
     "* $T_k$ is equal to 1 if the digit of class $k$ is present, or 0 otherwise.\n",
     "* In the paper, $m^{+} = 0.9$, $m^{-} = 0.1$ and $\\lambda = 0.5$.\n",


### PR DESCRIPTION
Hi,

thanks for that great explanation of CapsNet and its implementation.

This PR fixes the margin loss formula to be identical with equation (4) in the original paper.