### PR TITLE
made initial weights higher-variance

### DIFF
--- a/extra_capsnets.ipynb
+++ b/extra_capsnets.ipynb
@@ -607,7 +607,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Okay, let's start by creating a trainable variable of shape (1, 1152, 10, 16, 8) that will hold all the transformation matrices. The first dimension of size 1 will make this array easy to tile. We initialize this variable randomly using a normal distribution with a standard deviation to 0.01."
+    "Okay, let's start by creating a trainable variable of shape (1, 1152, 10, 16, 8) that will hold all the transformation matrices. The first dimension of size 1 will make this array easy to tile. We initialize this variable randomly using a normal distribution with a standard deviation to 0.1."
    ]
   },
   {
@@ -616,7 +616,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "init_sigma = 0.01\n",
+    "init_sigma = 0.1\n",
     "\n",
     "W_init = tf.random_normal(\n",
     "    shape=(1, caps1_n_caps, caps2_n_caps, caps2_n_dims, caps1_n_dims),\n",


### PR DESCRIPTION
It looks like your initialization for transformation matrices between primary capsules and digit capsules is very unfortunate. It typically takes ~50 batches (I use batch size 16) to start changing losses in visible range. This is a typical sign of bad initialization.
After this initial delay training takes on quite rapidly, so it does not look like bad LR
When I change stddev of initial weights from 0.01 to 0.1, models starts visible learning right away

So IMHO it makes sense to change value in notebook as well