### PR TITLE
OpenAI gym support in docker image

### DIFF
--- a/16_reinforcement_learning.ipynb
+++ b/16_reinforcement_learning.ipynb
@@ -3050,6 +3050,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openai_cart_pole_rendering = False  # don't try, just use the safe way?"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 26,
    "metadata": {},
    "outputs": [

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,12 +6,15 @@ RUN apt-get update && apt-get upgrade -y \
         build-essential \
         git \
         sudo \
+        cmake zlib1g-dev libjpeg-dev xvfb libav-tools xorg-dev libboost-all-dev libsdl2-dev swig \
     && rm -rf /var/lib/apt/lists/*
 
 RUN conda update -n base conda
 RUN conda install -y -c conda-forge \
         tensorflow \
-        jupyter_contrib_nbextensions
+        jupyter_contrib_nbextensions \
+        pyopengl
+RUN pip install "gym[atari,box2d,classic_control]"
 
 ARG username
 ARG userid


### PR DESCRIPTION
Ok, I upgraded the Dockerfile for 16th chapter's notebook to resolve <https://github.com/ageron/handson-ml/issues/191>.
I've also rebuilt my local the image using the new anaconda3 base image and can confirm that now the code for chapter 16 seems to work - up to 4-million-step-training in section 10.3, at least :-)
I didn't include 'mujoco' and 'robotics' in the gym as they require some proprietary code (step that is not automated by openai).
One tweak I had to do was disabling `openai_cart_pole_rendering` so I include that also in PR - perhaps it'd be simpler/safer just to use the custom function?
