### PR TITLE
This addresses occasional MNIST fetch failure

### DIFF
--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -92,8 +92,27 @@
     }
    ],
    "source": [
+    "#from sklearn.datasets import fetch_mldata\n",
+    "#mnist = fetch_mldata('MNIST original')\n",
+    "from six.moves import urllib\n",
     "from sklearn.datasets import fetch_mldata\n",
-    "mnist = fetch_mldata('MNIST original')\n",
+    "\n",
+    "from scipy.io import loadmat\n",
+    "mnist_alternative_url = \"https://github.com/amplab/datascience-sp14/raw/master/lab7/mldata/mnist-original.mat\"\n",
+    "mnist_path = \"./mnist-original.mat\"\n",
+    "response = urllib.request.urlopen(mnist_alternative_url)\n",
+    "with open(mnist_path, \"wb\") as f:\n",
+    "    content = response.read()\n",
+    "    f.write(content)\n",
+    "mnist_raw = loadmat(mnist_path)\n",
+    "mnist = {\n",
+    "    \"data\": mnist_raw[\"data\"].T,\n",
+    "    \"target\": mnist_raw[\"label\"][0],\n",
+    "    \"COL_NAMES\": [\"label\", \"data\"],\n",
+    "    \"DESCR\": \"mldata.org dataset: mnist-original\",\n",
+    "}\n",
+    "print(\"Success!\")\n",
+    "\n",
     "mnist"
    ]
   },


### PR DESCRIPTION
Sometimes this does not fetch successfully.
```
mnist = fetch_mldata('MNIST original')
```