### PR TITLE
fixing breaking change introduced by jupyter minor version update

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,4 +18,4 @@ services:
       - "6006:6006"
     volumes:
       - ../:/home/devel/handson-ml
-    command: /opt/conda/bin/jupyter notebook --ip='*' --port=8888 --no-browser
+    command: /opt/conda/bin/jupyter notebook --ip='0.0.0.0' --port=8888 --no-browser


### PR DESCRIPTION
Jupyter introduced a breaking change in minor versions, the --ip='*' is no longer usable. Resulting error after docker-compose up:
![image](https://user-images.githubusercontent.com/11783702/47956577-e7200280-dfa6-11e8-9ceb-4eb4f6b78d3b.png)

Issue + fix:
https://github.com/jupyter/docker-stacks/issues/718