### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ Great! You're all set, you just need to start Jupyter now.
 ## Starting Jupyter
 If you want to use the Jupyter extensions (optional, they are mainly useful to have nice tables of contents), you first need to install them:
 
-    $ jupyter contrib nbextension install --user
+    $ conda install -c conda-forge jupyter_contrib_nbextensions
+    $ conda install -c conda-forge jupyter_nbextensions_configurator
 
-Then you can activate an extension, such as the Table of Contents (2) extension:
+Then you can activate an extension, such as the "Table of Contents (2)" extension:
 
     $ jupyter nbextension enable toc2/main
 


### PR DESCRIPTION
This line:
 $ jupyter contrib nbextension install --user

Caused an error on my mac: 
(mlbook) macs-Mac-mini:dev mac$ jupyter contrib nbextension install --user
Error executing Jupyter command 'contrib': [Errno 2] No such file or directory

Then I used the following commands to adjust everything:
conda install -c conda-forge jupyter_contrib_nbextensions
conda install -c conda-forge jupyter_nbextensions_configurator

That I've got from this website: 
https://ndres.me/post/best-jupyter-notebook-extensions/

So, my suggestion is to add those lines instead, mentioning that you can access the config website to activate whatever you want. 

Merci.