### PR TITLE
Add a conda env as option for readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ This installs the latest version of TensorFlow available for Anaconda (which is 
 Next, you can optionally install Jupyter extensions. These are useful to have nice tables of contents in the notebooks, but they are not required.
 
     $ conda install -n mlbook -c conda-forge jupyter_contrib_nbextensions
+    
+For a proper usage of the examples in the book, an `environment.yml` file is provided with the same packages (and versions)
+as in `requeriments.txt`. This way, you can generate pretty much the same environment using Python `virtualenv` or `conda`.
+You can do it out-of-the-box, just run the following command:
+
+    $ conda env create -f environment.yml
+    
+Doing so, you now have a conda environment named `mlbook` ready to use! Just activate it, then you have everything setted up
+for you.
 
 You are all set! Next, jump to the [Starting Jupyter](#starting-jupyter) section.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,60 @@
+channels:
+  - conda-forge
+dependencies:
+  ##### Core scientific packages
+  - python >=3.0
+  - jupyter==1.0.0
+  - pip
+  - matplotlib==3.0.3
+  - numpy==1.16.2
+  - pandas==0.24.1
+  - scipy==1.2.1
+
+  ##### Machine Learning packages
+  - scikit-learn==0.20.3
+  - xgboost==0.82
+
+  ##### Deep Learning packages
+  # Replace tensorflow with tensorflow-gpu if you want GPU support. If so,
+  # you need a GPU card with CUDA Compute Capability 3.0 or higher support, and
+  # you must install CUDA, cuDNN and more: see tensorflow.org for the detailed
+  # installation instructions.
+  - tensorflow==1.13.1
+  #- tensorflow-gpu==1.13.1
+
+  # Optional: OpenAI gym is only needed for the Reinforcement Learning chapter.
+  # There are a few dependencies you need to install first, check out:
+  # https://github.com/openai/gym#installing-everything
+  #- pip:
+    #- gym[all]==0.10.9
+    # If you only want to install the Atari dependency, uncomment this line instead:
+    #- gym[atari]==0.10.9
+
+  ##### Image manipulation
+  - imageio==2.5.0
+  - pillow==6.2.0
+  - scikit-image==0.14.2
+
+  ##### Extra packages (optional)
+  # Nice utility to diff Jupyter Notebooks.
+  #- nbdime==1.0.5
+
+  # May be useful with Pandas for complex "where" clauses (e.g., Pandas
+  # tutorial).
+  - numexpr==2.6.9
+
+  # Optional: these libraries can be useful in the classification chapter,
+  # exercise 4.
+  - nltk==3.4.5
+  - pip:
+    - urlextract==0.9
+
+  # Optional: tqdm displays nice progress bars, ipywidgets for tqdm's notebook support
+  - tqdm==4.31.1
+  - ipywidgets==7.4.2
+
+  # Optional: Some useful extensions to customize and configure jupyter notebooks
+  - jupyter_contrib_nbextensions
+  - jupyter_nbextensions_configurator
+
+name: mlbook


### PR DESCRIPTION
Hi, @ageron!

First of all, congratulations for your great book!

I'm trying here to do a very small contributions in this PR, aiming for `conda` users (just like me). I'm adding an `environment.yml` with the same setup as `requirements.txt`. So, the user now can generate the same environment both for `virtualenv` (with the `requirements.txt`) and `conda` (with the new file).

To do so, one can just run:

```console
$ conda env create -f environment.yml
```

An advantage with this contribution is the enhanced reproducibility. Also, it is easier for the user, since the user doesn't need to care about packages and versions (everything is already configured) A drawback is that when you update `requirements.txt`, you have to update `environment.yml` as well, to match packages' versions. Put it simply, both files have to be maintained.

I updated README with instructions. Please, do a double check there!

Thanks and I hope that you appreciate this PR!