### PR TITLE
Add mybinder.org link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Simply open the [Jupyter](http://jupyter.org/) notebooks you are interested in:
 * Using [jupyter.org's notebook viewer](http://nbviewer.jupyter.org/github/ageron/handson-ml/blob/master/index.ipynb)
     * note: [github.com's notebook viewer](https://github.com/ageron/handson-ml/blob/master/index.ipynb) also works but it is slower and the math formulas are not displayed correctly,
 * by cloning this repository and running Jupyter locally. This option lets you play around with the code. In this case, follow the installation instructions below,
+* on mybinder.org by clicking the badge: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ageron/handson-ml/master) (no account or login needed)
 * or by running the notebooks in [Deepnote](https://beta.deepnote.com). This allows you to play around with the code online in your browser. For example, here's a link to the first chapter: [<img height="22"  src="https://beta.deepnote.com/buttons/launch-in-deepnote.svg">](https://beta.deepnote.com/launch?template=data-science&url=https%3A//github.com/ageron/handson-ml/blob/master/02_end_to_end_machine_learning_project.ipynb)
 
 # Installation


### PR DESCRIPTION
mybinder.org is a free infrastructure operated by Project Binder. The [software used to operate it is open-source](binderhub.readthedocs.io/), based on JupyterHub and even the deployment/operations are [performed in the open by a team of volunteers](https://github.com/jupyterhub/mybinder.org-deploy/).

What do you think?