### PR TITLE
allow jupter to start as root

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       - "6006:6006"
     volumes:
       - ../:/home/devel/handson-ml
-    command: /opt/conda/bin/jupyter notebook --ip='0.0.0.0' --port=8888 --no-browser
+    command: /opt/conda/bin/jupyter notebook --ip='0.0.0.0' --port=8888 --no-browser --allow-root


### PR DESCRIPTION
After building the docker image successfully, Jupyter refuses to start saying it needs `--allow-root` flag. 