### PR TITLE
Update 03_classification.ipynb

### DIFF
--- a/03_classification.ipynb
+++ b/03_classification.ipynb
@@ -95,6 +95,8 @@
    "outputs": [],
    "source": [
     "def sort_by_target(mnist):\n",
+    "    mnist.data = mnist.data.values\n",
+    "    mnist.target = mnist.target.values\n",
     "    reorder_train = np.array(sorted([(target, i) for i, target in enumerate(mnist.target[:60000])]))[:, 1]\n",
     "    reorder_test = np.array(sorted([(target, i) for i, target in enumerate(mnist.target[60000:])]))[:, 1]\n",
     "    mnist.data[:60000] = mnist.data[reorder_train]\n",


### PR DESCRIPTION
When I tried to run cell 2, I got the error "KeyError: "None of [Int64Index([    1,    21,    34,    37,    51,    56,    63,    68,    69,\n               75,\n            ...\n            59910, 59917, 59927, 59939, 59942, 59948, 59969, 59973, 59990,\n            59992],\n           dtype='int64', length=60000)] are in the [columns]". Apparently openml is returning a Pandas Dataframe here whereas it must have used to return a Numpy array; I had to make this change to get it to work correctly.